### PR TITLE
Update install cmd to not specifiy release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Download and extract the scan plugin to `~/.kube/plugins/scan`:
 
 ```bash
 mkdir -p ~/.kube/plugins/scan && \
-curl -sL https://github.com/stefanprodan/kubectl-kubesec/releases/download/0.2.0/kubectl-kubesec_0.2.0_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
+curl -sL https://github.com/stefanprodan/kubectl-kubesec/releases/download/<release-version>/kubectl-kubesec_<release-version>_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
 ```
 
 ### Usage


### PR DESCRIPTION
Thought it would be better for the readme to not have to be constantly updated when ever a new release is created.